### PR TITLE
Debug and Fix Syntax Errors

### DIFF
--- a/windows10esu-discovery.ps1
+++ b/windows10esu-discovery.ps1
@@ -7,7 +7,7 @@
 
 $ActivationIDs = @(
   'f520e45e-7413-4a34-a497-d2765967d094', # Year 1
-  '1043add5d-23b1-4afb-9a0f-64343c8f3f8d', # Year 2
+  '1043add5-23b1-4afb-9a0f-64343c8f3f8d', # Year 2
   '83d49986-add3-41d7-ba33-87c7bfb5c0fb'  # Year 3
 ) | ForEach-Object { $_.ToLower() }  # normalize case
 


### PR DESCRIPTION
Corrected typo in Year 2 ESU Activation ID from '1043add5d-...' to '1043add5-...' The extra 'd' character created a malformed GUID (9 chars instead of 8 in first section) which prevented detection of Year 2 ESU licenses. GUID format should be 8-4-4-4-12.

This now matches the correct GUID used in the remediation script.